### PR TITLE
implement workflows for automatic releases

### DIFF
--- a/.github/workflows/prepare-new-version.yml
+++ b/.github/workflows/prepare-new-version.yml
@@ -1,0 +1,43 @@
+name: Prepare new Release
+run-name: ${{ github.actor }} is preparing a new Release 🚀
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Define Harbor Version
+
+jobs:
+  prepare_new_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare Repository
+        run: |
+          git fetch
+          git switch release-version-${{ github.event.inputs.version }} || git switch -c release-version-${{ github.event.inputs.version }}
+          git config user.name ${{ github.actor }}
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+      - name: Update Version
+        run: |
+          sed -E "s/v[0-9]+\.[0-9]+\.[0-9]+/v${{ github.event.inputs.version }}/g" -i README.md
+          sed -E "s/(VERSION := )v[0-9]+\.[0-9]+\.[0-9]+/\1v${{ github.event.inputs.version }}/g" -i Makefile
+          make gen-harbor-api
+      - name: Commit and Push Changes
+        run: |
+          git add -A
+          git commit -m "Release Version ${{ github.event.inputs.version }}" || echo "Nothing to commit"
+          git push origin release-version-${{ github.event.inputs.version }}
+      - name: Create Pull Request
+        run: |
+          if gh pr view release-version-${{ github.event.inputs.version }}; then
+            echo "Pull request release-version-${{ github.event.inputs.version }} already exists"
+            exit 0
+          else
+            echo "Creating Pull request release-version-${{ github.event.inputs.version }}"
+            gh pr create -B main -H release-version-${{ github.event.inputs.version }} --title 'Release Version ${{ github.event.inputs.version }}' --body 'Created by Github action'
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,26 @@
+name: Release new Version Tag
+run-name: ${{ github.actor }} is tagging a new Release 🚀
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: create tag
+        run: |
+          version=$(make get-go-version)
+          if gh release view ${version} &> /dev/null; then
+            echo "Release ${version} already exists"
+            exit 0
+          else
+            echo "Creating Release ${version}"
+            gh release create "${version}"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,6 @@
 # go-client
 Client library with golang for accessing Harbor API.
 
-## Client Types
-
-There are 3 swagger files in this repo.
-
-```sh
-api/
-    v2.0/
-        legacy_swagger.yaml    # legacy client
-        swagger.yaml           # v2 client
-    swagger.yaml               # assist client contains version and chart healthcheck
-
-```
-
 ## Download swagger spec by version
 
 Currently, the default Harbor version is `v2.8.2`.
@@ -62,6 +49,4 @@ c := Config{
 cs := NewClientSet(c)
 
 cs.V2() // v2 client
-cs.Legacy() // legacy client
-cs.Assist() // assist client
 ```


### PR DESCRIPTION
As discussed in https://github.com/goharbor/go-client/pull/19, I did implement some workflows to automate the release process. This process now looks like:

1. Trigger Workflow: Prepare new Release
    * Can be executed manually or included in some other workflow
    * Takes the new version as input argument
    * Updates the Readme + Makefile, runs `make gen-harbor-api`
    * Creates a PR
2. Manually review PR + merge it
3. Automatically triggered Workflow: Release new Version Tag
    * Runs on PR merge (or actually push to main)
    * Creates the Release + Tag

This requires the setting `Allow GitHub Actions to create and approve pull requests` in `Settings > Actions > General` to be enabled.

Tested in https://github.com/luka5/go-client/pulls