### PR TITLE
Security: NewClientSet skips TLS verification even when Insecure is false

### DIFF
--- a/pkg/harbor/client.go
+++ b/pkg/harbor/client.go
@@ -76,7 +76,7 @@ func (c *Config) ToV2Config() v2client.Config {
 	}
 
 	if t == nil {
-		t = InsecureTransport
+		t = http.DefaultTransport
 	}
 
 	return v2client.Config{

--- a/pkg/harbor/client_test.go
+++ b/pkg/harbor/client_test.go
@@ -60,6 +60,18 @@ var params = []testParam{
 		expectedAuthInfo:  nil,
 		clientType:        v2Type,
 	},
+	testParam{
+		// no transport set should default to a verifying transport, not InsecureTransport
+		url:               "//10.0.0.1:443",
+		transport:         nil,
+		authInfo:          nil,
+		expectedHost:      "10.0.0.1:443",
+		expectedBasePath:  v2client.DefaultBasePath,
+		expectedScheme:    httpsSchema,
+		expectedTransport: http.DefaultTransport,
+		expectedAuthInfo:  nil,
+		clientType:        v2Type,
+	},
 }
 
 func TestToConfig(t *testing.T) {


### PR DESCRIPTION
`NewClientSet` never verifies server certificates, even when `Insecure` is left
at its default of `false`. The `Insecure` flag effectively does nothing.

Here's the path. `NewClientSet` only sets a transport when `Insecure` is true:

```go
if csc.Insecure {
    c.Transport = InsecureTransport
}
```

Otherwise `c.Transport` stays `nil`, and `ToV2Config` fills that `nil` in with
`InsecureTransport`:
```go
if t == nil {
    t = InsecureTransport
}
```
  
So both paths end up on `InsecureTransport` (which sets InsecureSkipVerify: true). Whether you pass Insecure: true or Insecure: false, the resulting client skips certificate verification. Anyone who called NewClientSet with Insecure: false expecting a safe default has been talking to Harbor over an unverified TLS connection without realizing it.

The fix defaults a nil transport to http.DefaultTransport instead of InsecureTransport. http.DefaultTransport verifies certificates normally, and Insecure: true still works because it sets InsecureTransport explicitly before ToV2Config runs, so the nil branch never applies to it.

**Heads up**, this is a behavior change. If you were calling NewClientSet with Insecure: false against a server with a self-signed or otherwise untrusted certificate, it used to "work" by silently skipping verification, and it will now correctly fail the TLS handshake. The fix on your side is to trust the cert/CA, or set Insecure: true if you really do want to skip verification.

Testing: added a case to the existing TestToConfig table for the nil-transport path, asserting it resolves to http.DefaultTransport. It fails on the current code (which returns InsecureTransport) and passes with this change.

`go test ./pkg/harbor/...` is green.
